### PR TITLE
feat: filecoin address compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@chakra-ui/react": "^2.4.9",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
+        "@glif/filecoin-address": "^2.0.37",
         "@netlify/functions": "^1.4.0",
         "ethers": "^5.7.2",
         "framer-motion": "^8.5.3",
@@ -2889,6 +2890,32 @@
         "@ethersproject/strings": "^5.7.0"
       }
     },
+    "node_modules/@glif/filecoin-address": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/@glif/filecoin-address/-/filecoin-address-2.0.37.tgz",
+      "integrity": "sha512-U7e2fwUI/RVuI/nY/os16BoaUk9vky/PyfEmk4BHTf6v5pXD5pKMecMVmmELfUZYRq0qDQ8t1y4eAKr9a4Mrbw==",
+      "dependencies": {
+        "blakejs": "1.1.0",
+        "borc": "3.0.0",
+        "ethers": "^5.7.2",
+        "leb128": "0.0.5",
+        "node-int64": "^0.4.0",
+        "uint8arrays": "3.0.0"
+      }
+    },
+    "node_modules/@glif/filecoin-address/node_modules/blakejs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+      "integrity": "sha512-1TSf2Cf2KycDPzjJpzamYhr6PFSEgKWyoc4rQ/BarXJzp/jM0FC7yP1rLWtMOWT2EIJtjPv9fwpKquRNbRV7Lg=="
+    },
+    "node_modules/@glif/filecoin-address/node_modules/uint8arrays": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
+      "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -3447,6 +3474,14 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/@sovpro/delimited-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@sovpro/delimited-stream/-/delimited-stream-1.1.0.tgz",
+      "integrity": "sha512-kQpk267uxB19X3X2T1mvNMjyvIEonpNSHrMlK5ZaBU6aZxw7wPbpgKJOjHN3+/GPVpXgAV9soVT2oyHpLkLtyw==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@stablelib/aead": {
@@ -6020,6 +6055,14 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
+      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -6050,6 +6093,29 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+    },
+    "node_modules/borc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/borc/-/borc-3.0.0.tgz",
+      "integrity": "sha512-ec4JmVC46kE0+layfnwM3l15O70MlFiEbmQHY/vpqIKiUtPVntv4BY4NVnz3N4vb21edV3mY97XVckFvYHWF9g==",
+      "dependencies": {
+        "bignumber.js": "^9.0.0",
+        "buffer": "^6.0.3",
+        "commander": "^2.15.0",
+        "ieee754": "^1.1.13",
+        "iso-url": "^1.1.5",
+        "json-text-sequence": "~0.3.0",
+        "readable-stream": "^3.6.0"
+      },
+      "bin": {
+        "cbor2comment": "bin/cbor2comment.js",
+        "cbor2diag": "bin/cbor2diag.js",
+        "cbor2json": "bin/cbor2json.js",
+        "json2cbor": "bin/json2cbor.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/borsh": {
       "version": "0.7.0",
@@ -6274,6 +6340,14 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/buffer-pipe": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-pipe/-/buffer-pipe-0.0.3.tgz",
+      "integrity": "sha512-GlxfuD/NrKvCNs0Ut+7b1IHjylfdegMBxQIlZHj7bObKVQBxB5S84gtm2yu1mQ8/sSggceWBDPY0cPXgvX2MuA==",
+      "dependencies": {
+        "safe-buffer": "^5.1.2"
+      }
     },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
@@ -9341,6 +9415,14 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/iso-url": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
+      "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/isomorphic-timers-promises": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-timers-promises/-/isomorphic-timers-promises-1.0.1.tgz",
@@ -9999,6 +10081,17 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
+    "node_modules/json-text-sequence": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.3.0.tgz",
+      "integrity": "sha512-7khKIYPKwXQem4lWXfpIN/FEnhztCeRPSxH4qm3fVlqulwujrRDD54xAwDDn/qVKpFtV550+QAkcWJcufzqQuA==",
+      "dependencies": {
+        "@sovpro/delimited-stream": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.18.0"
+      }
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -10092,6 +10185,15 @@
       "dev": true,
       "dependencies": {
         "language-subtag-registry": "~0.3.2"
+      }
+    },
+    "node_modules/leb128": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/leb128/-/leb128-0.0.5.tgz",
+      "integrity": "sha512-elbNtfmu3GndZbesVF6+iQAfVjOXW9bM/aax9WwMlABZW+oK9sbAZEXoewaPHmL34sxa8kVwWsru8cNE/yn2gg==",
+      "dependencies": {
+        "bn.js": "^5.0.0",
+        "buffer-pipe": "0.0.3"
       }
     },
     "node_modules/levn": {
@@ -10696,6 +10798,11 @@
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
       }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
     },
     "node_modules/node-releases": {
       "version": "2.0.8",
@@ -15706,6 +15813,34 @@
         "@ethersproject/strings": "^5.7.0"
       }
     },
+    "@glif/filecoin-address": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/@glif/filecoin-address/-/filecoin-address-2.0.37.tgz",
+      "integrity": "sha512-U7e2fwUI/RVuI/nY/os16BoaUk9vky/PyfEmk4BHTf6v5pXD5pKMecMVmmELfUZYRq0qDQ8t1y4eAKr9a4Mrbw==",
+      "requires": {
+        "blakejs": "1.1.0",
+        "borc": "3.0.0",
+        "ethers": "^5.7.2",
+        "leb128": "0.0.5",
+        "node-int64": "^0.4.0",
+        "uint8arrays": "3.0.0"
+      },
+      "dependencies": {
+        "blakejs": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+          "integrity": "sha512-1TSf2Cf2KycDPzjJpzamYhr6PFSEgKWyoc4rQ/BarXJzp/jM0FC7yP1rLWtMOWT2EIJtjPv9fwpKquRNbRV7Lg=="
+        },
+        "uint8arrays": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
+          "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
+          "requires": {
+            "multiformats": "^9.4.2"
+          }
+        }
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -16140,6 +16275,11 @@
           }
         }
       }
+    },
+    "@sovpro/delimited-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@sovpro/delimited-stream/-/delimited-stream-1.1.0.tgz",
+      "integrity": "sha512-kQpk267uxB19X3X2T1mvNMjyvIEonpNSHrMlK5ZaBU6aZxw7wPbpgKJOjHN3+/GPVpXgAV9soVT2oyHpLkLtyw=="
     },
     "@stablelib/aead": {
       "version": "1.0.1",
@@ -18234,6 +18374,11 @@
         "bindings": "^1.3.0"
       }
     },
+    "bignumber.js": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
+      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig=="
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -18261,6 +18406,20 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+    },
+    "borc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/borc/-/borc-3.0.0.tgz",
+      "integrity": "sha512-ec4JmVC46kE0+layfnwM3l15O70MlFiEbmQHY/vpqIKiUtPVntv4BY4NVnz3N4vb21edV3mY97XVckFvYHWF9g==",
+      "requires": {
+        "bignumber.js": "^9.0.0",
+        "buffer": "^6.0.3",
+        "commander": "^2.15.0",
+        "ieee754": "^1.1.13",
+        "iso-url": "^1.1.5",
+        "json-text-sequence": "~0.3.0",
+        "readable-stream": "^3.6.0"
+      }
     },
     "borsh": {
       "version": "0.7.0",
@@ -18446,6 +18605,14 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "buffer-pipe": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-pipe/-/buffer-pipe-0.0.3.tgz",
+      "integrity": "sha512-GlxfuD/NrKvCNs0Ut+7b1IHjylfdegMBxQIlZHj7bObKVQBxB5S84gtm2yu1mQ8/sSggceWBDPY0cPXgvX2MuA==",
+      "requires": {
+        "safe-buffer": "^5.1.2"
+      }
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -20814,6 +20981,11 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "iso-url": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
+      "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng=="
+    },
     "isomorphic-timers-promises": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-timers-promises/-/isomorphic-timers-promises-1.0.1.tgz",
@@ -21309,6 +21481,14 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
+    "json-text-sequence": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.3.0.tgz",
+      "integrity": "sha512-7khKIYPKwXQem4lWXfpIN/FEnhztCeRPSxH4qm3fVlqulwujrRDD54xAwDDn/qVKpFtV550+QAkcWJcufzqQuA==",
+      "requires": {
+        "@sovpro/delimited-stream": "^1.1.0"
+      }
+    },
     "json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -21377,6 +21557,15 @@
       "dev": true,
       "requires": {
         "language-subtag-registry": "~0.3.2"
+      }
+    },
+    "leb128": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/leb128/-/leb128-0.0.5.tgz",
+      "integrity": "sha512-elbNtfmu3GndZbesVF6+iQAfVjOXW9bM/aax9WwMlABZW+oK9sbAZEXoewaPHmL34sxa8kVwWsru8cNE/yn2gg==",
+      "requires": {
+        "bn.js": "^5.0.0",
+        "buffer-pipe": "0.0.3"
       }
     },
     "levn": {
@@ -21846,6 +22035,11 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
       "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ=="
+    },
+    "node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
     },
     "node-releases": {
       "version": "2.0.8",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@chakra-ui/react": "^2.4.9",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
+    "@glif/filecoin-address": "^2.0.37",
     "@netlify/functions": "^1.4.0",
     "ethers": "^5.7.2",
     "framer-motion": "^8.5.3",

--- a/src/abi.json
+++ b/src/abi.json
@@ -88,9 +88,14 @@
         "name": "payout",
         "inputs": [
             {
-                "internalType": "address[]",
+                "internalType": "struct CommonTypes.FilAddress[]",
                 "name": "payees",
-                "type": "address[]"
+                "type": "tuple[]",
+                "components": [
+                    {
+                        "type": "bytes"
+                    }
+                ]
             },
             {
                 "internalType": "uint256[]",
@@ -125,9 +130,14 @@
         "name": "releasable",
         "inputs": [
             {
-                "internalType": "address",
+                "internalType": "struct CommonTypes.FilAddress",
                 "name": "account",
-                "type": "address"
+                "type": "tuple",
+                "components": [
+                    {
+                        "type": "bytes"
+                    }
+                ]
             }
         ],
         "outputs": [
@@ -144,9 +154,14 @@
         "name": "releasablePerContract",
         "inputs": [
             {
-                "internalType": "address",
+                "internalType": "struct CommonTypes.FilAddress",
                 "name": "account",
-                "type": "address"
+                "type": "tuple",
+                "components": [
+                    {
+                        "type": "bytes"
+                    }
+                ]
             }
         ],
         "outputs": [
@@ -173,9 +188,14 @@
         "name": "releaseAll",
         "inputs": [
             {
-                "internalType": "address",
+                "internalType": "struct CommonTypes.FilAddress",
                 "name": "account",
-                "type": "address"
+                "type": "tuple",
+                "components": [
+                    {
+                        "type": "bytes"
+                    }
+                ]
             }
         ],
         "outputs": [],
@@ -186,9 +206,14 @@
         "name": "releaseSelect",
         "inputs": [
             {
-                "internalType": "address",
+                "internalType": "struct CommonTypes.FilAddress",
                 "name": "account",
-                "type": "address"
+                "type": "tuple",
+                "components": [
+                    {
+                        "type": "bytes"
+                    }
+                ]
             },
             {
                 "internalType": "address[]",
@@ -204,9 +229,14 @@
         "name": "released",
         "inputs": [
             {
-                "internalType": "address",
+                "internalType": "struct CommonTypes.FilAddress",
                 "name": "account",
-                "type": "address"
+                "type": "tuple",
+                "components": [
+                    {
+                        "type": "bytes"
+                    }
+                ]
             }
         ],
         "outputs": [
@@ -259,9 +289,14 @@
         "name": "shares",
         "inputs": [
             {
-                "internalType": "address",
+                "internalType": "struct CommonTypes.FilAddress",
                 "name": "account",
-                "type": "address"
+                "type": "tuple",
+                "components": [
+                    {
+                        "type": "bytes"
+                    }
+                ]
             }
         ],
         "outputs": [
@@ -354,8 +389,13 @@
         "inputs": [
             {
                 "name": "to",
-                "type": "address",
-                "indexed": false
+                "type": "tuple",
+                "indexed": false,
+                "components": [
+                    {
+                        "type": "bytes"
+                    }
+                ]
             },
             {
                 "name": "amount",

--- a/src/components/AddressChangeForm.tsx
+++ b/src/components/AddressChangeForm.tsx
@@ -18,7 +18,7 @@ import {
     ModalOverlay,
     Text,
 } from '@chakra-ui/react';
-import { isAddress } from 'ethers/lib/utils';
+import { validateAddressString } from '@glif/filecoin-address';
 import { useState } from 'react';
 import { FormEvent } from 'react';
 import { Connector } from 'wagmi';
@@ -48,7 +48,7 @@ function WalletForm(props: { address: string; connector: Connector }) {
         event.preventDefault();
         const address = event.currentTarget.value;
 
-        if (isAddress(address)) {
+        if (validateAddressString(address)) {
             setFormValidation(true);
             setUserAddress(address);
             return;
@@ -61,17 +61,16 @@ function WalletForm(props: { address: string; connector: Connector }) {
         <>
             <ModalBody>
                 <Heading size="lg" m={4}>
-                    Selected Address: {truncateEthAddress(props.address)}
+                    Connected Wallet Address:{' '}
+                    {truncateEthAddress(props.address)}
                 </Heading>
                 <Divider mb={4} />
                 <Text fontSize={'xl'}>
-                    Please confirm your Saturn Node operator address. To change
-                    the address, you can either select a different address from
-                    your browser wallet or manually insert one.
-                </Text>
-                <Text fontSize={'xl'}>
-                    If you are depositing into an exchange wallet, insert the
-                    exchange manually by clicking on &quot;Change Address&quot;.
+                    This is the wallet address you will be connecting with. This
+                    is not meant to be your filecoin address. If you desire to
+                    connect with a different wallet then please select a
+                    different account from your wallet provider. Otherwise,
+                    proceed to insert your Filecoin Address.
                 </Text>
             </ModalBody>
             <ModalFooter>
@@ -79,15 +78,6 @@ function WalletForm(props: { address: string; connector: Connector }) {
                     <Button
                         leftIcon={<EditIcon />}
                         onClick={() => setChangeAddress(true)}
-                    >
-                        Change Address
-                    </Button>
-                    <Button
-                        leftIcon={<CheckIcon />}
-                        onClick={() => {
-                            setUserAddress(props.address);
-                            setSubmitted(true);
-                        }}
                     >
                         Proceed
                     </Button>
@@ -99,17 +89,21 @@ function WalletForm(props: { address: string; connector: Connector }) {
     const addressSubmitForm = (
         <>
             <ModalBody>
+                <Text fontSize={'xl'} mb={4}>
+                    Please insert the filecoin address that you will be claiming
+                    for earnings for.
+                </Text>
                 <FormControl isRequired isInvalid={formValid === false}>
                     <FormLabel aria-label="Wallet Address">
-                        Wallet Address
+                        Filecoin Address
                     </FormLabel>
                     <Input
                         onChange={onAddressChange}
-                        placeholder="Ethereum Address"
+                        placeholder="Filecoin Address"
                     />
                     {formValid === true ? (
                         <FormHelperText>
-                            Enter a valid Ethereum address.
+                            Enter a valid Filecoin address.
                         </FormHelperText>
                     ) : (
                         <FormErrorMessage>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -36,6 +36,7 @@ import {
     getRelease,
     getUserInfo,
     truncateEthAddress,
+    truncateFilecoinAddress,
 } from '../utils/wagmi-utils';
 import DataTable from './DataTable';
 import InfoModal from './InfoModal';
@@ -62,13 +63,13 @@ const UserDashboard = (props: { address: string }) => {
         }
     }, [chain]);
     const address = props.address;
-    const { connector, status } = useAccount();
+    const { address: walletAddress, connector, status } = useAccount();
     if (status === 'disconnected') {
         window.location.href = '/connect';
     }
 
     const { data: balanceData, isLoading: isBalanceLoading } = useBalance({
-        address: address as Address,
+        address: walletAddress as Address,
     });
 
     const contractFuncs = address && (getUserInfo(address) as any);
@@ -124,8 +125,9 @@ const UserDashboard = (props: { address: string }) => {
     const balance = isBalanceLoading ? (
         skeletonComp
     ) : (
-        <Text fontSize={'xl'} fontWeight="bold" alignSelf={'flex-start'}>
-            Balance: {balanceData?.formatted.slice(0, FIL_BALANCE_MAX_DIGITS)}{' '}
+        <Text fontSize={'md'} fontWeight="bold" alignSelf={'flex-start'}>
+            {connector?.name} Balance:{' '}
+            {balanceData?.formatted.slice(0, FIL_BALANCE_MAX_DIGITS)}{' '}
             {balanceData?.symbol}
         </Text>
     );
@@ -153,14 +155,26 @@ const UserDashboard = (props: { address: string }) => {
     const header = address && connector && (
         <>
             <HStack spacing={'10'} flexWrap="wrap">
-                <Avatar size={'lg'} />
-                <VStack>
-                    <Heading size={'lg'} alignSelf="flex-start">
-                        {truncateEthAddress(address)}{' '}
+                <Avatar size={'xl'} />
+                <VStack spacing={0}>
+                    <Heading size={'lg'} alignSelf="flex-start" mb={3}>
+                        Viewing earnings for {truncateFilecoinAddress(address)}
                     </Heading>
+                    <Text
+                        fontSize={'md'}
+                        fontWeight="bold"
+                        alignSelf={'flex-start'}
+                    >
+                        Connected to{' '}
+                        {truncateEthAddress(walletAddress as string)}
+                    </Text>
                     {balance}
-                    <Text alignSelf={'flex-start'}>
-                        Connected to {connector.name}
+                    <Text
+                        fontSize={'md'}
+                        fontWeight="bold"
+                        alignSelf={'flex-start'}
+                    >
+                        Network: {chain?.name}
                     </Text>
                 </VStack>
             </HStack>
@@ -171,26 +185,28 @@ const UserDashboard = (props: { address: string }) => {
     );
 
     const stats = data && (
-        <StatGroup mb={5}>
-            <Stat>
-                <StatLabel>
-                    <Heading size="sm"> Total Earnings</Heading>
-                </StatLabel>
-                <StatNumber> {data.stats.shares} FIL </StatNumber>
-            </Stat>
-            <Stat>
-                <StatLabel>
-                    <Heading size="sm"> Released Earnings</Heading>
-                </StatLabel>
-                <StatNumber>{data.stats.released} FIL</StatNumber>
-            </Stat>
-            <Stat>
-                <StatLabel>
-                    <Heading size="sm"> Claimable Earnings</Heading>
-                </StatLabel>
-                <StatNumber> {data.stats.releasable} FIL </StatNumber>
-            </Stat>
-        </StatGroup>
+        <>
+            <StatGroup mb={5} mt={4}>
+                <Stat>
+                    <StatLabel>
+                        <Heading size="sm"> Total Earnings</Heading>
+                    </StatLabel>
+                    <StatNumber> {data.stats.shares} FIL </StatNumber>
+                </Stat>
+                <Stat>
+                    <StatLabel>
+                        <Heading size="sm"> Released Earnings</Heading>
+                    </StatLabel>
+                    <StatNumber>{data.stats.released} FIL</StatNumber>
+                </Stat>
+                <Stat>
+                    <StatLabel>
+                        <Heading size="sm"> Claimable Earnings</Heading>
+                    </StatLabel>
+                    <StatNumber> {data.stats.releasable} FIL </StatNumber>
+                </Stat>
+            </StatGroup>
+        </>
     );
 
     if (!mounted) {
@@ -210,7 +226,7 @@ const UserDashboard = (props: { address: string }) => {
                     >
                         {header}
                     </Stack>
-                    <Divider mt={10} mb={2} />
+                    <Divider mt={1} mb={2} />
 
                     <CardBody>
                         {isLoading ? loadingSkeleton : stats}

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -20,7 +20,11 @@ import {
 } from 'wagmi';
 
 import { ContractError, ContractItem, DashboardContracts } from '../types';
-import { factoryContract, truncateEthAddress } from '../utils/wagmi-utils';
+import {
+    factoryContract,
+    formatAddressForContract,
+    truncateEthAddress,
+} from '../utils/wagmi-utils';
 
 const DataTable = (props: {
     contracts: DashboardContracts;
@@ -68,7 +72,7 @@ const DataTable = (props: {
         contracts &&
         Object.values(contracts).filter((item: ContractItem) => item.checked);
     const writeArgs = [
-        props.address,
+        formatAddressForContract(props.address),
         selectedContracts.map((item: ContractItem) => item.address),
     ];
 


### PR DESCRIPTION
## Changes:
- Enabling users to claim earnings using their filecoin address.

## Notes:
- There is a bit of awkwardness with the current flow, as EVM compatible wallets (eg Metamask) will show an Ethereum formatted address for the user. Therefore, the address you connect with and the address you claim for are different. This will require some iteration to get right from the UX perspective as this is highly likely to cause confusion for users. 


<img width="1415" alt="Screen Shot 2023-03-13 at 8 49 15 PM" src="https://user-images.githubusercontent.com/43304401/224864109-d07f64c2-45bf-49df-940e-7ef23e61044e.png">

